### PR TITLE
Add lenient type-checking with pytype

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -48,6 +48,12 @@ RUN dnf -y install \
     python \
     python-pip
 
+# python3.12, g++ and python-headers for pytype
+RUN dnf -y --setopt=install_weak_deps=False install \
+    gcc-c++ \
+    python3.12 \
+    python3.12-devel
+
 # ---
 # Final setup steps
 # ---

--- a/.github/workflows/check-python.yml
+++ b/.github/workflows/check-python.yml
@@ -45,3 +45,22 @@ jobs:
     - uses: actions/checkout@v4
     - name: Ruff
       uses: chartboost/ruff-action@v1
+
+  typing:
+    continue-on-error: true
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python 3.12 (Latest which pytype supports)
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.12"
+    - name: Setup just
+      uses: taiki-e/install-action@just
+    - name: Install dependencies
+      run: |
+        just install
+    - name: Run pytype
+      run: |
+        pytype .
+    

--- a/.github/workflows/check-python.yml
+++ b/.github/workflows/check-python.yml
@@ -62,5 +62,5 @@ jobs:
         just install
     - name: Run pytype
       run: |
-        pytype .
+        just type-check
     

--- a/.github/workflows/check-python.yml
+++ b/.github/workflows/check-python.yml
@@ -46,8 +46,8 @@ jobs:
     - name: Ruff
       uses: chartboost/ruff-action@v1
 
-  typing:
-    continue-on-error: true
+  type-check:
+    continue-on-error: false # make typing mandatory (for now) as pytype is lenient by design
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/check-python.yml
+++ b/.github/workflows/check-python.yml
@@ -5,7 +5,7 @@ on:
     paths: 
     - "**.py"
     - "**pyproject.toml"
-    - ".github/workflows/python.yml"
+    - ".github/workflows/check-python.yml"
   pull_request:
   workflow_call:
 

--- a/.gitignore
+++ b/.gitignore
@@ -129,7 +129,7 @@ celerybeat.pid
 
 # Environments
 .env
-.venv
+.venv*
 env/
 venv/
 ENV/

--- a/justfile
+++ b/justfile
@@ -21,16 +21,14 @@ clean:
 clean-cov:
     rm -rf pycov
 
-# clean, remove existing .venv and rebuild the venvs with pip install -e .[dev]
-reset: clean clean-cov newvenv install (newvenv "python3.12" ".venv-3.12") (install ".venv-3.12")
+# clean, remove existing .venvs and rebuild the venvs with pip install -e .[dev]
+reset: clean clean-cov && install (install "python3.12" ".venv-3.12")
+    rm -rf .venv*
 
-#create a new virtual environment, optionally for a specific python executable in a specific path
-newvenv python="python" venvpath=venv:
-  rm -rf {{venvpath}}
-  {{python}} -m venv {{venvpath}}
-
-# install the project and required dependecies for development & testing
-install venvpath=venv:
+# (re-)create a venv and install the project and required dependecies for development & testing
+install python="python" venvpath=venv:
+    rm -rf {{venvpath}}
+    {{python}} -m venv {{venvpath}}
     {{venvpath}}/bin/python -m pip install --upgrade pip 
     {{venvpath}}/bin/pip install -e .[dev]
 

--- a/justfile
+++ b/justfile
@@ -1,8 +1,10 @@
+venv := ".venv"
+
 # list available recipes
 list:
   @just --list --justfile {{justfile()}}
   
-# remove pre-built python libraries (excluding .venv)
+# remove pre-built python libraries (excluding those in .venvs)
 clean:
     rm -rf .pytest_cache
     rm -rf build
@@ -20,25 +22,25 @@ clean-cov:
     rm -rf pycov
 
 # clean, remove existing .venv and rebuild the venvs with pip install -e .[dev]
-reset: clean clean-cov newvenv install (newvenv "python3.12" ".venv-3.12") (install ".venv-3.12/bin/")
+reset: clean clean-cov newvenv install (newvenv "python3.12" ".venv-3.12") (install ".venv-3.12")
 
 #create a new virtual environment, optionally for a specific python executable in a specific path
-newvenv python="python" venvpath=".venv":
+newvenv python="python" venvpath=venv:
   rm -rf {{venvpath}}
   {{python}} -m venv {{venvpath}}
 
 # install the project and required dependecies for development & testing
-install venvpath=".venv/bin/":
-    {{venvpath}}python -m pip install --upgrade pip 
-    {{venvpath}}pip install -e .[dev]
+install venvpath=venv:
+    {{venvpath}}/bin/python -m pip install --upgrade pip 
+    {{venvpath}}/bin/pip install -e .[dev]
 
 # lint python with ruff
 lint:
-  - .venv/bin/ruff check .
+  - {{venv}}/bin/ruff check .
 
 # test python
 test:
-  - .venv/bin/pytest
+  - {{venv}}/bin/pytest
 
 # type-check python
 type-check:

--- a/justfile
+++ b/justfile
@@ -10,7 +10,7 @@ clean:
     rm -rf dist
     rm -rf wheelhouse
     rm -rf .ruff_cache
-    find . -depth -type d -not -path "./.venv/*" -name "__pycache__" -exec rm -rf "{}" \;
+    find . -depth -type d -not -path "./.venv*/*" -name "__pycache__" -exec rm -rf "{}" \;
     find . -depth -type d -path "*.egg-info" -exec rm -rf "{}" \;
     find . -type f -name "*.egg" -delete
     find . -type f -name "*.so" -delete
@@ -19,13 +19,16 @@ clean:
 clean-cov:
     rm -rf pycov
 
-# clean, remove existing .venv and rebuild the venv with pip install -e .[dev]
-reset: clean clean-cov && (install ".venv/bin/")
-    rm -rf .venv
-    python -m venv .venv
+# clean, remove existing .venv and rebuild the venvs with pip install -e .[dev]
+reset: clean clean-cov newvenv install (newvenv "python3.12" ".venv-3.12") (install ".venv-3.12/bin/")
+
+#create a new virtual environment, optionally for a specific python executable in a specific path
+newvenv python="python" venvpath=".venv":
+  rm -rf {{venvpath}}
+  {{python}} -m venv {{venvpath}}
 
 # install the project and required dependecies for development & testing
-install venvpath="":
+install venvpath=".venv/bin/":
     {{venvpath}}python -m pip install --upgrade pip 
     {{venvpath}}pip install -e .[dev]
 
@@ -37,8 +40,12 @@ lint:
 test:
   - .venv/bin/pytest
 
+# type-check python
+type-check:
+  - .venv-3.12/bin/pytype .
+
 # lint and test python
-check: lint test
+check: lint test type-check
 
 #run coverage analysis on python code
 cov:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,10 @@
 # ===========================
 
 [project.optional-dependencies]
-    lint = ["ruff", "pytype"]
+    lint = [
+        "ruff",
+        "pytype; python_version <= '3.12'"
+    ]
     test = ["pytest", "pytest-doctest-mkdocstrings"]
     cov = ["ttrpg-dice[test]", "pytest-cov"]
     doc = ["black", "mkdocs", "mkdocstrings[python]", "mkdocs-material"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,7 +73,6 @@
     flake8-annotations.mypy-init-return = true
     extend-ignore = [
         "E701",   # One-line ifs are not great, one-liners with suppression are worse
-        "ANN101", # Type annotation for `self`
         "ANN202", # Return type annotation for private functions
         "ANN401", # Using Any often enough that supressing individually is pointless
         "W291",   # Double space at EOL is linebreak in md-docstring

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,7 @@
         "--doctest-glob=*.pyi",
         "--doctest-glob=*.md",
     ]
-    testpaths = ["tests", "ttrpg-dice"]
+    testpaths = ["tests", "ttrpg_dice"]
 
 [tool.coverage.run]
     branch = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@
 # ===========================
 
 [project.optional-dependencies]
-    lint = ["ruff"]
+    lint = ["ruff", "pytype"]
     test = ["pytest", "pytest-doctest-mkdocstrings"]
     cov = ["ttrpg-dice[test]", "pytest-cov"]
     doc = ["black", "mkdocs", "mkdocstrings[python]", "mkdocs-material"]


### PR DESCRIPTION
- Add required python version to devcontainer
- Install pytype as part of [lint] on supported versions
- Update justfile to install and run pytype in additional python3.12 venv
- Update check-python workflow to run pytype