### PR TITLE
fix docs publishing after moving to uv

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -26,6 +26,8 @@ concurrency:
 jobs:
   # Build job
   build:
+    env:
+      python-version: '3.13'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -34,16 +36,16 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.x"
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install .[doc]
+          python-version: ${{ env.python-version }}
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          python-version: ${{ env.python-version }}
       - name: Setup Pages
         id: pages
         uses: actions/configure-pages@v5
       - name: Build with mkdocs
-        run: mkdocs build
+        run: uv run --no-default-groups --group doc mkdocs build
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:

--- a/justfile
+++ b/justfile
@@ -65,4 +65,4 @@ show-cov:
 
 # serve python docs on localhost:8000
 docs:
-  mkdocs serve
+  uv run mkdocs serve


### PR DESCRIPTION
## Summary by Sourcery

Update the CI workflow to use Python 3.13 and integrate the 'uv' tool for building and publishing documentation.

CI:
- Update the GitHub Actions workflow to use Python 3.13 for building and publishing documentation.
- Integrate the 'uv' tool in the CI workflow to run mkdocs build commands.